### PR TITLE
scripts/integrations.json: update homepageurl of @analogjs/astro-angular

### DIFF
--- a/scripts/integrations.json
+++ b/scripts/integrations.json
@@ -171,6 +171,9 @@
 		"astro-integration-elm": {
 			"image": "/assets/integrations/astro-integration-elm.svg"
 		},
+		"@analogjs/astro-angular": {
+			"homepageUrl": "https://analogjs.org/docs/packages/astro-angular/overview"
+		},
 		"@chisel-ui/astro": {
 			"description": "A collection of layout primitives used as building blocks for common layout patterns.",
 			"image": "/assets/integrations/chisel-ui.svg",


### PR DESCRIPTION
It prevents the old url to come back on nightly build when
    npm run update:integrations -- --unsafe
is ran

<!-- Briefly describe what this PR does in a few words or more, for future readers to understand the context of this change. -->

## Browser Test Checklist

<!--
Test on as many of these browsers as you can, ideally 3+ of them.

Tests for all browsers are **strongly recommended** if this PR includes:

- Large gradients or the usage of `mask-image`, which can cause perf issues on Firefox Android (https://github.com/withastro/astro.build/pull/780)
- Font changes, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/1028)
- Adding SVGs, which can behave strangely on Safari (https://github.com/withastro/astro.build/pull/769)
-->

I have tested this PR on at least three of the following browsers:

- [ ] Chrome / Chromium
- [ ] Firefox
- [ ] Android Firefox
- [ ] Safari
- [ ] iOS Safari

